### PR TITLE
Switch legacy `slackclient` to `slack_sdk`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,9 +6,9 @@ verify_ssl = true
 [packages]
 codepost = "*"
 pytz = "*"
-slackclient = "*"
 pyyaml = "*"
 cryptography = "*"
+slack-sdk = "*"
 
 [dev-packages]
 autopep8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6557b2b41ac1bd34e8a2f42c652e48dc8d48d06f1d31beb0d387e2c6ea0279b2"
+            "sha256": "19ed1a3c1e2aba1a019ae2bfda8c68a621cd2d951ce4c7623f8e283319a4e3e2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -231,7 +231,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==2.1.1"
         },
         "codepost": {
@@ -287,7 +287,7 @@
                 "sha256:adc9c05263aa5527f1679e9af65728a06df1485f5a5e1ea94bc6f7081c14e479",
                 "sha256:c2f099a3e8d5ecfc22745766e7cc664a48db64b6b89d986dff270491d8683149"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==1.14.0"
         },
         "frozenlist": {
@@ -548,13 +548,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
-        "slackclient": {
+        "slack-sdk": {
             "hashes": [
-                "sha256:a8cab9146795e23d66a03473b80dd23df8c500829dfa9d06b3e3d5aec0a2b293",
-                "sha256:ab79fefb5412d0595bc01d2f195a787597f2a617b6766562932ab9ffbe5cb173"
+                "sha256:316574ffaf0f5c55bd08476b0a34f3bd2caa9b90b814859bc22922f25934d3aa",
+                "sha256:88ddf46f42f95568cffbab8c69de7e7bfacce9b13829d9214a8aee2b70b0a4b7"
             ],
             "index": "pypi",
-            "version": "==2.9.4"
+            "version": "==3.19.3"
         },
         "typing": {
             "hashes": [
@@ -859,45 +859,23 @@
         },
         "psutil": {
             "hashes": [
-                "sha256:07d880053c6461c9b89cd5d4808f3b8336665fa3acdefd6777662c5ed73a851a",
-                "sha256:12500d761ac091f2426567f19f95fd3f15a197d96befb44a5c1e3cbe6db5752c",
-                "sha256:1b540599481c73408f6b392cdffef5b01e8ff7a2ac8caae0a91b8222e88e8f1e",
-                "sha256:35feafe232d1aaf35d51bd42790cbccb882456f9f18cdc411532902370d660df",
-                "sha256:3a7826e68b0cf4ce2c1ee385d64eab7d70e3133171376cac53d7c1790357ec8f",
-                "sha256:46907fa62acaac364fff0b8a9da7b360265d217e4fdeaca0a2397a6883dffba2",
-                "sha256:4bd4854f0c83aa84a5a40d3b5d0eb1f3c128f4146371e03baed4589fe4f3c931",
-                "sha256:538fcf6ae856b5e12d13d7da25ad67f02113c96f5989e6ad44422cb5994ca7fc",
-                "sha256:547ebb02031fdada635452250ff39942db8310b5c4a8102dfe9384ee5791e650",
-                "sha256:5e8b50241dd3c2ed498507f87a6602825073c07f3b7e9560c58411c14fe1e1c9",
-                "sha256:5fa88e3d5d0b480602553d362c4b33a63e0c40bfea7312a7bf78799e01e0810b",
-                "sha256:68fa227c32240c52982cb931801c5707a7f96dd8927f9102d6c7771ea1ff5698",
-                "sha256:6ced1ad823ecfa7d3ce26fe8aa4996e2e53fb49b7fed8ad81c80958501ec0619",
-                "sha256:71b1206e7909792d16933a0d2c1c7f04ae196186c51ba8567abae1d041f06dcb",
-                "sha256:767ef4fa33acda16703725c0473a91e1832d296c37c63896c7153ba81698f1ab",
-                "sha256:7ccfcdfea4fc4b0a02ca2c31de7fcd186beb9cff8207800e14ab66f79c773af6",
-                "sha256:7e4939ff75149b67aef77980409f156f0082fa36accc475d45c705bb00c6c16a",
-                "sha256:828c9dc9478b34ab96be75c81942d8df0c2bb49edbb481f597314d92b6441d89",
-                "sha256:8a4e07611997acf178ad13b842377e3d8e9d0a5bac43ece9bfc22a96735d9a4f",
-                "sha256:941a6c2c591da455d760121b44097781bc970be40e0e43081b9139da485ad5b7",
-                "sha256:9a4af6ed1094f867834f5f07acd1250605a0874169a5fcadbcec864aec2496a6",
-                "sha256:9ec296f565191f89c48f33d9544d8d82b0d2af7dd7d2d4e6319f27a818f8d1cc",
-                "sha256:9ec95df684583b5596c82bb380c53a603bb051cf019d5c849c47e117c5064395",
-                "sha256:a04a1836894c8279e5e0a0127c0db8e198ca133d28be8a2a72b4db16f6cf99c1",
-                "sha256:a3d81165b8474087bb90ec4f333a638ccfd1d69d34a9b4a1a7eaac06648f9fbe",
-                "sha256:b4a247cd3feaae39bb6085fcebf35b3b8ecd9b022db796d89c8f05067ca28e71",
-                "sha256:ba38cf9984d5462b506e239cf4bc24e84ead4b1d71a3be35e66dad0d13ded7c1",
-                "sha256:beb57d8a1ca0ae0eb3d08ccaceb77e1a6d93606f0e1754f0d60a6ebd5c288837",
-                "sha256:d266cd05bd4a95ca1c2b9b5aac50d249cf7c94a542f47e0b22928ddf8b80d1ef",
-                "sha256:d8c3cc6bb76492133474e130a12351a325336c01c96a24aae731abf5a47fe088",
-                "sha256:db8e62016add2235cc87fb7ea000ede9e4ca0aa1f221b40cef049d02d5d2593d",
-                "sha256:e7507f6c7b0262d3e7b0eeda15045bf5881f4ada70473b87bc7b7c93b992a7d7",
-                "sha256:ed15edb14f52925869250b1375f0ff58ca5c4fa8adefe4883cfb0737d32f5c02",
-                "sha256:f57d63a2b5beaf797b87024d018772439f9d3103a395627b77d17a8d72009543",
-                "sha256:fa5e32c7d9b60b2528108ade2929b115167fe98d59f89555574715054f50fa31",
-                "sha256:fe79b4ad4836e3da6c4650cb85a663b3a51aef22e1a829c384e18fae87e5e727"
+                "sha256:149555f59a69b33f056ba1c4eb22bb7bf24332ce631c44a319cec09f876aaeff",
+                "sha256:16653106f3b59386ffe10e0bad3bb6299e169d5327d3f187614b1cb8f24cf2e1",
+                "sha256:3d7f9739eb435d4b1338944abe23f49584bde5395f27487d2ee25ad9a8774a62",
+                "sha256:3ff89f9b835100a825b14c2808a106b6fdcc4b15483141482a12c725e7f78549",
+                "sha256:54c0d3d8e0078b7666984e11b12b88af2db11d11249a8ac8920dd5ef68a66e08",
+                "sha256:54d5b184728298f2ca8567bf83c422b706200bcbbfafdc06718264f9393cfeb7",
+                "sha256:6001c809253a29599bc0dfd5179d9f8a5779f9dffea1da0f13c53ee568115e1e",
+                "sha256:68908971daf802203f3d37e78d3f8831b6d1014864d7a85937941bb35f09aefe",
+                "sha256:6b92c532979bafc2df23ddc785ed116fced1f492ad90a6830cf24f4d1ea27d24",
+                "sha256:852dd5d9f8a47169fe62fd4a971aa07859476c2ba22c2254d4a1baa4e10b95ad",
+                "sha256:9120cd39dca5c5e1c54b59a41d205023d436799b1c8c4d3ff71af18535728e94",
+                "sha256:c1ca331af862803a42677c120aff8a814a804e09832f166f226bfd22b56feee8",
+                "sha256:efeae04f9516907be44904cc7ce08defb6b665128992a56957abc9b61dca94b7",
+                "sha256:fd8522436a6ada7b4aad6638662966de0d61d241cb821239b2ae7013d41a43d4"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==5.9.3"
+            "version": "==5.9.4"
         },
         "ptyprocess": {
             "hashes": [

--- a/read_config.py
+++ b/read_config.py
@@ -41,19 +41,18 @@ def _validate_slack_channels(slack_client, channels, fmt_error):
     errors = []
     for channel, channel_id in channels.items():
         try:
-            slack_client.chat_scheduledMessages_list(channel=channel_id)
+            # https://api.slack.com/methods/conversations.info
+            slack_client.conversations_info(channel=channel_id)
         except SlackApiError as e:
             if not e.response or e.reponse.get('ok', None) is not False:
                 raise
             reason = e.response.get('error', None)
             if reason is None:
                 raise
-            if reason == 'invalid_channel':
-                # invalid channel id: {"ok": False, "error": "invalid_channel"}
+            if reason == 'channel_not_found':
                 errors.append(
                     fmt_error('Invalid id for Slack channel "{}"', channel))
-            elif reason == 'not_in_channel':
-                # not in channel: {"ok": False, "error": "not_in_channel"}
+            elif reason == 'missing_scope':
                 errors.append(
                     fmt_error('Slack key does not have access to channel "{}"',
                               channel))

--- a/read_config.py
+++ b/read_config.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import codepost
 import pytz
 import yaml
-from slack.errors import SlackApiError
+from slack_sdk.errors import SlackApiError
 
 from utils import _error, get_slack_client, now_dt, validate_codepost
 
@@ -43,9 +43,8 @@ def _validate_slack_channels(slack_client, channels, fmt_error):
         try:
             slack_client.chat_scheduledMessages_list(channel=channel_id)
         except SlackApiError as e:
-            if not e.response:
+            if not e.response or e.reponse.get('ok', None) is not False:
                 raise
-            # assume e.response['ok'] = False
             reason = e.response.get('error', None)
             if reason is None:
                 raise

--- a/utas_slack_bot.py
+++ b/utas_slack_bot.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import codepost
 from cryptography.fernet import Fernet, InvalidToken
-from slack.errors import SlackApiError
+from slack_sdk.errors import SlackApiError
 
 import read_config
 from utils import _error, get_slack_client, now, validate_codepost

--- a/utils.py
+++ b/utils.py
@@ -70,9 +70,9 @@ def get_slack_client(slack_token):
     slack_client = WebClient(token=slack_token)
     try:
         # validate the token
+        # https://api.slack.com/methods/auth.test
         slack_client.api_test()
     except SlackApiError as e:
-        # invalid auth: {"ok": False, "error": "invalid_auth"}
         if e.response['error'] == 'invalid_auth':
             return False, None
         raise

--- a/utils.py
+++ b/utils.py
@@ -9,8 +9,8 @@ from datetime import datetime
 
 import codepost
 import pytz
-from slack import WebClient
-from slack.errors import SlackApiError
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
 
 # ==============================================================================
 
@@ -69,12 +69,11 @@ def get_slack_client(slack_token):
     """
     slack_client = WebClient(token=slack_token)
     try:
-        # validate the token using some random GET request
-        slack_client.chat_scheduledMessages_list()
+        # validate the token
+        slack_client.api_test()
     except SlackApiError as e:
-        # e.response should be: {"ok": False, "error": "invalid_auth"}
-        if (e.response and not e.response.get('ok', False) and
-                e.response.get('error', None) == 'invalid_auth'):
+        # invalid auth: {"ok": False, "error": "invalid_auth"}
+        if e.response['error'] == 'invalid_auth':
             return False, None
         raise
     return True, slack_client


### PR DESCRIPTION
The `slackclient` package is a legacy package whose successor is [`slack_sdk`](https://pypi.org/project/slack-sdk/). However, I don't have a valid slack token to test that `get_slack_client()` in `utils.py` still works properly.